### PR TITLE
Remove cartopy dependency

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,11 +102,9 @@ To run 𝛿MG as a framework or package, it must be installed as a package. This
 
   ```bash
   pip install ./generic_deltamodel[hydrodl2]
-  ```
 
-  or
+  # or
 
-  ```bash
   uv pip install ./generic_deltamodel[hydrodl2]
   ```
 
@@ -117,15 +115,25 @@ To run 𝛿MG as a framework or package, it must be installed as a package. This
   ```bash
   git clone git@github.com:mhpi/hydrodl2.git
   pip install -e ./hydrodl2
-  ```
 
-  or
+  # or
 
-  ```bash
   uv pip install -e ./hydrodl2
   ```
 
   Note, developer mode will ensure hydrodl2 won't need to be reinstalled whenever you make changes.
+
+- Geo Plotting
+
+  - For geographical plotting features (e.g., mapping model metrics spatially) available in `./examples/`, install dependencies with
+
+  ```bash
+  pip install ./generic_deltamodel[geo]
+
+  # or
+
+  uv pip install ./generic_deltamodel[geo]
+  ```
 
 - Development
 
@@ -133,11 +141,9 @@ To run 𝛿MG as a framework or package, it must be installed as a package. This
 
   ```bash
   pip install ./generic_deltamodel[dev]
-  ```
 
-  or
+  # or
 
-  ```bash
   uv pip install ./generic_deltamodel[dev]
   ```
 

--- a/example/hydrology/README.md
+++ b/example/hydrology/README.md
@@ -5,11 +5,12 @@ This directory contains notebooks to train/test/forward 3 published differentiab
 1. HydroDL LSTM -- `example_lstm.ipynb`
 2. δHBV 1.0 -- `example_dhbv.ipynb`
 3. δHBV 1.1p -- `example_dhbv_1_1p.ipynb`
-4. δHBV 2.0UH -- `example_dhbv_2.ipynb` (forward simulation only)
-5. δHBV 2.0UH MTS -- `_example_dhbv2_mts.ipynb` (forward simulation; note this script is WIP and currently for development only.)
+4. δHBV 1.1p w/ GEFS -- `example_dhbv_1_1p_gefs.ipynb`
+5. δHBV 2.0UH -- `example_dhbv_2.ipynb` (forward simulation only)
+6. δHBV 2.0UH MTS -- `_example_dhbv2_mts.ipynb` (forward simulation; note this script is WIP and currently for development only.)
 
 We encourage you to check δHBV 1.0 first for detailed on differentiable modeling and dMG methods.
 
 All of these models rely on the bucket-based hydrology model HBV (Beck 2020; Seibert 2005) for making streamflow predictions.
 
-(1), (2) and (3) contain code to train, test, and forward benchmark versions of these models. Distributed model δHBV 2.0UH training and testing codes will be made available at a later date.
+(1 - 4) contain code to train, test, and forward benchmark versions of these models. Distributed model δHBV 2.0UH training and testing codes will be made available at a later date.

--- a/example/hydrology/example_dhbv.ipynb
+++ b/example/hydrology/example_dhbv.ipynb
@@ -851,7 +851,11 @@
     "\n",
     "This plot shows the locations of each basin in the evaluation data, color-coded by performance on a metric. Here we give a plot for NSE, but as before, this can be changed to your preference. (See above; for metrics not valued between 0 and 1, you will need to set `dynamic_colorbar=True` in `geoplot_single_metric` to ensure proper coding.)\n",
     "\n",
-    "Note, you will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running)."
+    "> Notes\n",
+    ">\n",
+    "> 1. You will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running).\n",
+    ">\n",
+    "> 2. To use `geoplot_single_metric`, make sure to install dMG with geo plotting dependencies like `uv pip install ./generic_deltamodel[geo]`."
    ]
   },
   {

--- a/example/hydrology/example_dhbv_1_1p.ipynb
+++ b/example/hydrology/example_dhbv_1_1p.ipynb
@@ -460,7 +460,11 @@
     "\n",
     "This plot shows the locations of each basin in the evaluation data, color-coded by performance on a metric. Here we give a plot for NSE, but as before, this can be changed to your preference. (See above; for metrics not valued between 0 and 1, you will need to set `dynamic_colorbar=True` in `geoplot_single_metric` to ensure proper coding.)\n",
     "\n",
-    "Note, you will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running)."
+    "> Notes\n",
+    ">\n",
+    "> 1. You will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running).\n",
+    ">\n",
+    "> 2. To use `geoplot_single_metric`, make sure to install dMG with geo plotting dependencies like `uv pip install ./generic_deltamodel[geo]`."
    ]
   },
   {

--- a/example/hydrology/example_dhbv_1_1p_gefs.ipynb
+++ b/example/hydrology/example_dhbv_1_1p_gefs.ipynb
@@ -922,7 +922,11 @@
     "\n",
     "This plot shows the locations of each basin in the evaluation data, color-coded by performance on a metric. Here we give a plot for NSE, but as before, this can be changed to your preference. (See above; for metrics not valued between 0 and 1, you will need to set `dynamic_colorbar=True` in `geoplot_single_metric` to ensure proper coding.)\n",
     "\n",
-    "Note, you will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running)."
+    "> Notes\n",
+    ">\n",
+    "> 1. You will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running).\n",
+    ">\n",
+    "> 2. To use `geoplot_single_metric`, make sure to install dMG with geo plotting dependencies like `uv pip install ./generic_deltamodel[geo]`."
    ]
   },
   {

--- a/example/hydrology/example_lstm.ipynb
+++ b/example/hydrology/example_lstm.ipynb
@@ -483,7 +483,11 @@
     "\n",
     "This plot shows the locations of each basin in the evaluation data, color-coded by performance on a metric. Here we give a plot for NSE, but as before, this can be changed to your preference. (See above; for metrics not valued between 0 and 1, you will need to set `dynamic_colorbar=True` in `geoplot_single_metric` to ensure proper coding.)\n",
     "\n",
-    "Note, you will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running)."
+    "> Notes\n",
+    ">\n",
+    "> 1. You will need to add paths to the CAMELS shapefile, gage IDs, and 531-gage subset which can be found in the [CAMELS download](#before-running).\n",
+    ">\n",
+    "> 2. To use `geoplot_single_metric`, make sure to install dMG with geo plotting dependencies like `uv pip install ./generic_deltamodel[geo]`."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ maintainers = [
 requires-python = ">=3.9.0"
 dynamic = ["version"]
 dependencies = [
-    "cartopy",
     "geopandas",
     "hydra-core",
     "ipykernel",
@@ -51,6 +50,9 @@ dev = [
     "pre-commit",
     "pytest",
     "ruff",
+]
+geo = [
+    "cartopy",
 ]
 hydrodl2 = [
     "hydrodl2 @ git+https://github.com/mhpi/hydrodl2.git@master"

--- a/src/dmg/core/post/plot_geo.py
+++ b/src/dmg/core/post/plot_geo.py
@@ -1,5 +1,12 @@
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
+try:
+    import cartopy.crs as ccrs
+    import cartopy.feature as cfeature
+except ImportError:
+    ccrs = None
+    cfeature = None
+
+from typing import Optional
+
 import geopandas as gpd
 import matplotlib.pyplot as plt
 
@@ -7,14 +14,14 @@ import matplotlib.pyplot as plt
 def geoplot_single_metric(
     gdf: gpd.GeoDataFrame,
     metric_name: str,
-    title: str = None,
-    map_color: bool = False,
-    draw_rivers: bool = False,
-    dynamic_colorbar: bool = False,
-    dpi: int = 100,
-    marker_size: int = 50,
+    title: Optional[str] = None,
+    map_color: Optional[bool] = False,
+    draw_rivers: Optional[bool] = False,
+    dynamic_colorbar: Optional[bool] = False,
+    dpi: Optional[int] = 100,
+    marker_size: Optional[int] = 50,
 ):
-    """Geographically map a single model performance metric using Basemap.
+    """Make a geographical map of a single performance metric using Basemap.
 
     Parameters
     ----------
@@ -24,7 +31,7 @@ def geoplot_single_metric(
         The name of the metric column to plot.
     title
         The title of the plot.
-    in_color
+    map_color
         Whether to use color for the map.
     draw_rivers
         Whether to draw rivers on the map.
@@ -36,6 +43,12 @@ def geoplot_single_metric(
     marker_size
         The size of the markers.
     """
+    if ccrs is None:
+        raise ImportError(
+            "cartopy is required for geo plotting. "
+            "Install with: uv pip install dmg[geo]"
+        )
+
     # Ensure the required columns are present in the GeoDataFrame
     if 'lat' not in gdf.columns or 'lon' not in gdf.columns:
         raise ValueError("The GeoDataFrame must include 'lat' and 'lon' columns.")


### PR DESCRIPTION
## Issue Addressed

Basically the title -- making Cartopy an optional dependency to streamline compatibility with NOAA-OWP and AWI operational frameworks.
<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

## Description

Add Cartopy as an optional dependency that can be installed like 

```bash
uv pip install ./generic_deltamodel[geo]
```

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup/refactor
- [x] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [ ] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation (if applicable)
- [x] Code follows established style and conventions
