### PR TITLE
Address denorm bugs

### DIFF
--- a/src/dmg/core/data/loaders/hydro_loader.py
+++ b/src/dmg/core/data/loaders/hydro_loader.py
@@ -196,10 +196,14 @@ class HydroLoader(BaseLoader):
             'target': self.to_tensor(target),
         }
 
-        # Attach function to convert model predictions back to mm/day.
+        # Attach functions to convert predictions and observations to output unit.
         if self.norm_target and scope != 'train':
             dataset['denorm_fn'] = partial(
                 self.denormalize_prediction,
+                c_nn,
+            )
+            dataset['obs_convert_fn'] = partial(
+                self.convert_obs_to_output_unit,
                 c_nn,
             )
 
@@ -722,6 +726,36 @@ class HydroLoader(BaseLoader):
                 data[..., k] = denormed
 
         return data
+
+    def convert_obs_to_output_unit(
+        self,
+        c_nn: NDArray[np.float32],
+        data: NDArray[np.float32],
+    ) -> NDArray[np.float32]:
+        """Convert observations from mm/day to the configured output unit.
+
+        Parameters
+        ----------
+        c_nn
+            Neural network static data.
+        data
+            Observation data in mm/day, shape (T, N, num_targets).
+
+        Returns
+        -------
+        NDArray[np.float32]
+            Observations in the configured output unit.
+        """
+        if self.output_unit == 'mm/d':
+            return data
+
+        area_name = self.config['observations']['area_name']
+        basin_area = c_nn[:, self.nn_attributes.index(area_name)]
+        area = np.expand_dims(basin_area, axis=0).repeat(data.shape[0], 0)
+
+        result = data.copy()
+        result[:, :, 0] = self._from_mm_per_day(result[:, :, 0], area)
+        return result
 
     def denormalize_prediction(
         self,

--- a/src/dmg/core/data/samplers/hydro_sampler.py
+++ b/src/dmg/core/data/samplers/hydro_sampler.py
@@ -122,4 +122,5 @@ class HydroSampler(BaseSampler):
                 device=self.device,
             )
             for key, value in dataset.items()
+            if hasattr(value, 'ndim')
         }

--- a/src/dmg/core/data/samplers/ms_hydro_sampler.py
+++ b/src/dmg/core/data/samplers/ms_hydro_sampler.py
@@ -69,6 +69,8 @@ class MsHydroSampler(BaseSampler):
         """Generate batch for model forwarding only."""
         dataset_sample = {}
         for key, value in dataset.items():
+            if not hasattr(value, 'ndim'):
+                continue
             if value.ndim == 3:
                 if key in ['x_phy', 'xc_nn_norm']:
                     warm_up = 0

--- a/src/dmg/trainers/trainer.py
+++ b/src/dmg/trainers/trainer.py
@@ -490,8 +490,15 @@ class Trainer(BaseTrainer):
         save_outputs(self.config, batch_predictions, observations)
         self._save_denormed_target(self.predictions)
 
+        # Convert observations to output unit before computing metrics so they
+        # match the (potentially denormalized) predictions.
+        obs_np = observations.cpu().numpy()
+        obs_convert_fn = self.eval_dataset.get('obs_convert_fn')
+        if obs_convert_fn is not None:
+            obs_np = obs_convert_fn(obs_np)
+
         # Calculate metrics
-        self.calc_metrics(self.predictions, observations)
+        self.calc_metrics(self.predictions, obs_np)
 
     def inference(self) -> None:
         """Run batch model inference and save model outputs."""
@@ -617,7 +624,7 @@ class Trainer(BaseTrainer):
     def calc_metrics(
         self,
         predictions: dict[str, np.ndarray],
-        observations: torch.Tensor,
+        observations: np.ndarray,
     ) -> None:
         """Calculate and save model performance metrics.
 
@@ -626,14 +633,15 @@ class Trainer(BaseTrainer):
         predictions
             Batched (and denormalized) predictions dict.
         observations
-            Target variable observation data.
+            Target variable observation data as a numpy array, already
+            converted to match the output unit of predictions.
         """
         target_name = self.config['train']['target'][0]
         warm_up = self.config['model'].get('warm_up', 0)
         pred = predictions[target_name]
         if pred.ndim == 2:
             pred = np.expand_dims(pred, 2)
-        target = np.expand_dims(observations[:, :, 0].cpu().numpy(), 2)
+        target = np.expand_dims(observations[:, :, 0], 2)
 
         target = target[warm_up:, :]
 


### PR DESCRIPTION
## Issue Addressed
Fix crash in `get_validation_sample` during evaluation/inference with LSTM models, and fix unit mismatch when computing metrics after denormalization.

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

## Description

Two bugs reported by @pyested:

- `get_validation_sample` crash: When `norm_target=True` (i.e. flow_regime is set), a `denorm_fn` partial object is stored in the dataset dict. Both `HydroSampler` and `MsHydroSampler` iterated over all dataset values and called `.ndim` on each, which fails for non-tensor objects. Fixed by skipping values that don't have `ndim` (`hasattr(value, 'ndim')`). This is robust to any future non-tensor dataset entries.

- Metrics unit mismatch: In `Trainer.evaluate`, predictions were denormalized to `output_unit` before metrics were computed, but observations were left in mm/d. This caused incorrect metrics whenever `output_unit != 'mm/d'`. Fixed by:
   - Adding `convert_obs_to_output_unit` to `HydroLoader`, which converts observations from mm/d to the configured `output_unit`.
   - Attaching an `obs_convert_fn` partial to the dataset alongside `denorm_fn`.
   - Applying `obs_convert_fn` to observations in `Trainer.evaluate` before calling `calc_metrics`, so predictions and observations are always in the same unit.

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [ ] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [x] Code follows established style and conventions
