### PR TITLE
Skip None tensors in Trainer._forward_loop

### DIFF
--- a/src/dmg/trainers/trainer.py
+++ b/src/dmg/trainers/trainer.py
@@ -617,6 +617,7 @@ class Trainer(BaseTrainer):
             prediction = {
                 key: tensor.detach().cpu()
                 for key, tensor in prediction[self.model.models[0]].items()
+                if tensor is not None
             }
             batch_predictions.append(prediction)
         return batch_predictions


### PR DESCRIPTION
Models can legitimately return None for optional fluxes/states in their output dict (e.g., HBV variants that omit certain quantities depending on configuration). The eval loop's dict comprehension currently calls .detach().cpu() on every value, which crashes with:

    AttributeError: 'NoneType' object has no attribute 'detach'

Defensive one-line guard: skip entries with tensor is None. Models that emit only real tensors are unaffected.

## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

## Description

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [ ] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [x] Code follows established style and conventions
