### PR TITLE
check_path: warn (don't raise) for unset template placeholders

### DIFF
--- a/src/dmg/core/utils/config.py
+++ b/src/dmg/core/utils/config.py
@@ -20,10 +20,30 @@ from dmg.core.utils.pydantic_compat import PYDANTIC_V2, v1_mock_self
 log = logging.getLogger(__name__)
 
 
+# Substrings that mark a value as an unset config template placeholder.
+# Validation logs a warning and defers to caller (e.g. programmatic override)
+# instead of raising, so a placeholder YAML can still be loaded and patched.
+_PLACEHOLDER_MARKERS = ('your/path/to', 'path/to/your')
+
+
 def check_path(key: str, v: str) -> Path:
-    """Checks if a given path exists and is valid."""
+    """Check that ``v`` is an existing path.
+
+    If ``v`` looks like an unset configuration template placeholder
+    (e.g. ``./your/path/to/...``), log a warning and return the path
+    object without erroring. This allows callers to instantiate a config
+    from a template and override paths programmatically before use.
+    Real missing paths (i.e. not matching any placeholder marker) still
+    raise as before.
+    """
     path = Path(v)
     if not path.exists():
+        if any(marker in str(v) for marker in _PLACEHOLDER_MARKERS):
+            log.warning(
+                f"{key} = {v!r} looks like an unset placeholder; "
+                f"skipping existence check. Override before use.",
+            )
+            return path
         log_str = f"Path does not exist for {key}: {v}"
         log.error(log_str)
         raise ValueError(log_str)


### PR DESCRIPTION
The documented config workflow is: clone the repo, edit `./your/path/to/...` placeholders in `observations/*.yaml` to point at real data, and run. However, the strict Pydantic validator raises ValueError on those placeholders immediately when `load_config()` is called, BEFORE any programmatic override (e.g. via Hydra CLI overrides or driver dict mutation) can take effect.

Detect the documented placeholder pattern ("your/path/to" or "path/to/your" substrings), log a warning, and return without error. Real missing paths still raise. This unblocks the placeholder-then-override pattern without weakening validation for genuine config mistakes.

## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

## Description

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
