### PR TITLE
fix(criterion): clamp negative predictions before sqrt in RmseCombLoss

### DIFF
--- a/src/dmg/models/criterion/rmse_comb_loss.py
+++ b/src/dmg/models/criterion/rmse_comb_loss.py
@@ -83,7 +83,13 @@ class RmseCombLoss(BaseCriterion):
             loss1 = torch.sqrt(((p_sub - t_sub) ** 2).mean())
 
             # Log-Sqrt RMSE
-            p_sub1 = torch.log10(torch.sqrt(p_sub + self.beta) + 0.1)
+            # Clamp predictions before sqrt: models with an unconstrained output head
+            # (e.g. LSTM) can predict negative flow, and sqrt(negative) = NaN poisons the
+            # entire loss from the first step. Physics models never trip this because their
+            # discharge is non-negative by construction, which is why the bug is silent in
+            # dHBV benchmarks and fatal for pure-NN ones. loss1 (plain RMSE) still supplies
+            # the gradient that pushes negative predictions back up.
+            p_sub1 = torch.log10(torch.sqrt(torch.clamp(p_sub, min=0.0) + self.beta) + 0.1)
             t_sub1 = torch.log10(torch.sqrt(t_sub + self.beta) + 0.1)
             loss2 = torch.sqrt(((p_sub1 - t_sub1) ** 2).mean())
 


### PR DESCRIPTION
The log-sqrt term computes torch.sqrt(p_sub + beta) with beta=1e-6. Any model with an unconstrained output head (e.g. CudnnLstmModel) can emit negative flow, making the sqrt NaN and poisoning the combined loss from the first training step. Physics-based models never trigger this because their simulated discharge is non-negative by construction (e.g. Q = S_prev - S_new), so the bug is invisible in dHBV benchmarks while making RmseCombLoss unusable for pure NN models.

Reproduction: CudnnLstmModel + RmseCombLoss on CAMELS -> loss = nan for all epochs. With this clamp the same run trains normally (0.716 -> 0.391 by epoch 44). The plain-RMSE term still provides the gradient that pushes negative predictions back toward positive values, so clamping the log-sqrt term does not remove the penalty on negative flows.

## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

## Description

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
